### PR TITLE
Reshuffle particles

### DIFF
--- a/src/IO/hdf5/common_hdf5.F90
+++ b/src/IO/hdf5/common_hdf5.F90
@@ -1195,7 +1195,6 @@ contains
       use cg_list,        only: cg_list_element
       use constants,      only: LO, HI, I_ONE
 #ifdef NBODY
-      use particle_utils, only: count_cg_particles
       use star_formation, only: pid_gen
 #endif /* NBODY */
 
@@ -1220,7 +1219,7 @@ contains
          cg_n_b(g, :) = cgl%cg%n_b(:)
          cg_off(g, :) = cgl%cg%my_se(:, LO) - cgl%cg%l%off(:)
 #ifdef NBODY
-         cg_npart(g)   = count_cg_particles(cgl%cg)
+         cg_npart(g)   = cgl%cg%count_particles()
          cg_pid_max(g) = pid_gen
 #endif /* NBODY */
          if (otype == O_OUT) then

--- a/src/IO/hdf5/particles_io.F90
+++ b/src/IO/hdf5/particles_io.F90
@@ -86,9 +86,8 @@ contains
 
    subroutine parallel_nbody_datafields(group_id, pvars, ncg, cg)
 
-      use grid_cont,      only: grid_container
-      use hdf5,           only: HID_T
-      use particle_utils, only: count_cg_particles
+      use grid_cont, only: grid_container
+      use hdf5,      only: HID_T
 
       implicit none
 
@@ -98,7 +97,7 @@ contains
       type(grid_container), pointer,  intent(inout) :: cg
       integer(kind=4)                               :: ivar, n_part
 
-      n_part = count_cg_particles(cg)
+      n_part = cg%count_particles()
       if (n_part == 0) return
 
       allocate(tabi(n_part), tabr(n_part))
@@ -120,11 +119,11 @@ contains
 
       use common_hdf5,    only: get_nth_cg, hdf_vars
       use constants,      only: I_ONE
+      use grid_cont,      only: grid_container
       use hdf5,           only: HID_T
       use MPIF,           only: MPI_INTEGER, MPI_STATUS_IGNORE, MPI_COMM_WORLD
       use MPIFUN,         only: MPI_Recv, MPI_Send
       use mpisetup,       only: master, FIRST, proc, err_mpi
-      use particle_utils, only: count_cg_particles
 
       implicit none
 
@@ -132,10 +131,14 @@ contains
       character(len=*), dimension(:), intent(in) :: pvars
       integer(kind=4),                intent(in) :: ncg, cg_src_ncg, proc_ncg, tot_cg_n
       integer(kind=4)                            :: ptag, ivar, n_part
+      type(grid_container), pointer              :: cg
 
       if (.not. master .and. proc_ncg /= proc) return
 
-      if (proc_ncg == proc) n_part = count_cg_particles(get_nth_cg(cg_src_ncg))
+      if (proc_ncg == proc) then
+         cg => get_nth_cg(cg_src_ncg)
+         n_part = cg%count_particles()
+      endif
 
       ptag = ncg + tot_cg_n * (ubound(hdf_vars, 1, kind=4) + I_ONE)
       if (master) then

--- a/src/grid/grid_container.F90
+++ b/src/grid/grid_container.F90
@@ -85,6 +85,7 @@ module grid_cont
       procedure :: print_tgt             !< Print all tgt_lists (for debugging only)
       procedure :: is_sending_fc_flux    !< Returns .true. if this block has fine hydro flux to be sent to some coarse block in specified direction
       procedure :: is_receiving_fc_flux  !< Returns .true. if this block expects fine hydro flux to be received from some fine block in specified direction
+      procedure :: count_particles       !< Returns the number of phy particles in this%pset
 
    end type grid_container
 
@@ -309,5 +310,25 @@ contains
       end subroutine pr_tgt
 
    end subroutine print_tgt
+
+!> \brief Returns the number of phy particles in this%pset
+
+   integer(kind=4) function count_particles(this) result(n_part)
+
+#if !defined(GRAV) || !defined(NBODY)
+      use constants, only: I_ZERO
+#endif
+
+      implicit none
+
+      class(grid_container), intent(in) :: this  !< an object invoking the type-bound procedure
+
+#if defined(GRAV) && defined(NBODY)
+      n_part = this%pset%count()
+#else
+      n_part = I_ZERO
+#endif
+
+   end function count_particles
 
 end module grid_cont

--- a/src/grid/grid_container.F90
+++ b/src/grid/grid_container.F90
@@ -86,6 +86,7 @@ module grid_cont
       procedure :: is_sending_fc_flux    !< Returns .true. if this block has fine hydro flux to be sent to some coarse block in specified direction
       procedure :: is_receiving_fc_flux  !< Returns .true. if this block expects fine hydro flux to be received from some fine block in specified direction
       procedure :: count_particles       !< Returns the number of phy particles in this%pset
+      procedure :: count_all_particles   !< Returns the number of all particles in this%pset
 
    end type grid_container
 
@@ -326,9 +327,29 @@ contains
 #if defined(GRAV) && defined(NBODY)
       n_part = this%pset%count()
 #else
-      n_part = I_ZERO
+      n_part = I_ZERO * this%membership  ! suppress compiler warnings
 #endif
 
    end function count_particles
+
+!> \brief Returns the number of phy particles in this%pset
+
+   integer(kind=4) function count_all_particles(this) result(n_part)
+
+#if !defined(GRAV) || !defined(NBODY)
+      use constants, only: I_ZERO
+#endif
+
+      implicit none
+
+      class(grid_container), intent(in) :: this  !< an object invoking the type-bound procedure
+
+#if defined(GRAV) && defined(NBODY)
+      n_part = this%pset%cnt
+#else
+      n_part = I_ZERO * this%membership  ! suppress compiler warnings
+#endif
+
+   end function count_all_particles
 
 end module grid_cont

--- a/src/grid/load_balance_helpers.F90
+++ b/src/grid/load_balance_helpers.F90
@@ -319,6 +319,7 @@ contains
       subroutine log_summary
 
          use dataio_pub, only: printinfo
+         use mpisetup,   only: nproc
          use procnames,  only: pnames
 
          implicit none
@@ -330,7 +331,7 @@ contains
          if (prev_time >= 0.) then
             dt_wall = MPI_Wtime() - prev_time
 
-            write(msg, '(a,f11.3,3a)') "All accumulated cg costs out of ", mul*dt_wall, " ", trim(prefix), "s"
+            write(msg, '(a,f11.3,3a,f5.1,a)') "All accumulated cg costs out of ", mul*dt_wall, " ", trim(prefix), "s, ", 100*sum(all_proc_stats(N_STATS, I_ONE, :))/nproc/dt_wall, "% spent on cg (averaged globally)"
             call printinfo(msg)
 
             do host = lbound(pnames%proc_on_node, 1), ubound(pnames%proc_on_node, 1)

--- a/src/grid/rebalance.F90
+++ b/src/grid/rebalance.F90
@@ -74,6 +74,7 @@ contains
 !      logical :: invalid_speed
       enum, bind(C)
          enumerator :: I_GID = I_N_B + ndims
+         enumerator :: I_NP = I_GID + I_ONE
       end enum
       integer(kind=4), parameter :: tag_gpt = 1, tag_cost = tag_gpt + 1  ! also used as counters for requests
       character(len=*), parameter :: cc_label = "collect_costs"
@@ -87,14 +88,15 @@ contains
 
          ! invalid_speed = .false.
          curl%recently_changed = .false.
-         allocate(gptemp(I_OFF:I_GID, curl%cnt), costs(curl%cnt), curl%cnt_all(FIRST:LAST))
+         allocate(gptemp(I_OFF:I_NP, curl%cnt), costs(curl%cnt), curl%cnt_all(FIRST:LAST))
 
          ! We have to use cgl%cg%old_costs because cgl%cg%costs was reset just before the call to refinement update
          i = 0
          cgl => curl%first
          do while (associated(cgl))
             i = i + I_ONE
-            gptemp(:, i) = [ cgl%cg%my_se(:, LO), int(cgl%cg%n_b, kind=8), int(cgl%cg%grid_id, kind=8) ]
+
+            gptemp(:, i) = [ cgl%cg%my_se(:, LO), int(cgl%cg%n_b, kind=8), int(cgl%cg%grid_id, kind=8), int(cgl%cg%count_all_particles(), kind=8) ]
             costs(i) = sum(cgl%cg%old_costs%wtime, mask=cost_mask(:))
             cgl => cgl%nxt
          enddo
@@ -106,7 +108,7 @@ contains
             do p = FIRST, LAST
                if (curl%cnt_all(p) > 0) then
                   if (p /= FIRST) then
-                     allocate(gptemp(I_OFF:I_GID, curl%cnt_all(p)), costs(curl%cnt_all(p)))
+                     allocate(gptemp(I_OFF:I_NP, curl%cnt_all(p)), costs(curl%cnt_all(p)))
                      call MPI_Recv(gptemp, size(gptemp, kind=4), MPI_INTEGER8,         p, tag_gpt,  MPI_COMM_WORLD, MPI_STATUS_IGNORE, err_mpi)
                      call MPI_Recv(costs,  size(costs, kind=4),  MPI_DOUBLE_PRECISION, p, tag_cost, MPI_COMM_WORLD, MPI_STATUS_IGNORE, err_mpi)
                   endif
@@ -128,6 +130,7 @@ contains
                      else
                         call curl%gp%list(i+ii)%set_gp(gptemp(I_OFF:I_OFF+ndims-1, i), int(gptemp(I_N_B:I_N_B+ndims-1, i), kind=4), int(gptemp(I_GID, i), kind=4), p)
                      endif
+                     curl%gp%list(i+ii)%n_part = int(gptemp(I_NP, i), kind=4)  ! should go to set_gp
                   enddo
                   ii = ii + curl%cnt_all(p)
                endif
@@ -412,6 +415,12 @@ contains
 #ifdef MPIF08
       use MPIF,               only: MPI_Comm
 #endif /* MPIF08 */
+#if defined(GRAV) && defined(NBODY)
+      use domain,             only: dom
+      use particle_func,      only: particle_in_area
+      use particle_types,     only: particle, P_ID, P_MASS, P_POS_X, P_POS_Z, P_VEL_X, P_VEL_Z, P_ACC_X, P_ACC_Z, P_ENER, P_TFORM, P_TDYN, npf
+      use particle_utils,     only: is_part_in_cg
+#endif /* GRAV && NBODY */
 
       implicit none
 
@@ -426,17 +435,21 @@ contains
       type :: cglep
          type(cg_list_element), pointer :: p
          real, dimension(:,:,:,:), allocatable :: tbuf
+#if defined(GRAV) && defined(NBODY)
+         real, dimension(:,:), allocatable :: pbuf
+#endif /* GRAV && NBODY */
       end type cglep
       type(cglep), allocatable, dimension(:) :: cglepa
       logical, parameter :: only_vital = .false. ! set to true to minimize the amount of data to be transferred, may result in improper calculation of error in maclaurin test
       !> \todo measure how much it costs in reality
       enum, bind(C)
-         enumerator :: I_OFF
-         enumerator :: I_N_B = I_OFF + ndims
-         enumerator :: I_GID = I_N_B + ndims
-         enumerator :: I_LEV
-         enumerator :: I_C_P
-         enumerator :: I_D_P
+         enumerator :: I_OFF                  ! cg offset
+         enumerator :: I_N_B = I_OFF + ndims  ! cg size
+         enumerator :: I_GID = I_N_B + ndims  ! cg%gid
+         enumerator :: I_LEV                  ! cg level
+         enumerator :: I_C_P                  ! cg process
+         enumerator :: I_D_P                  ! cg destination process
+         enumerator :: I_NP                   ! number of particles to transfer
       end enum
       character(len=*), parameter :: ISR_label = "reshuffle_Isend+Irecv", cp_label = "reshuffle_copy", gp_label = "reshuffle_gptemp"
 #ifdef MPIF08
@@ -444,23 +457,10 @@ contains
 #else /* !MPIF08 */
       integer(kind=4) :: shuff_comm
 #endif /* !MPIF08 */
-
-#ifdef NBODY
-      logical :: has_particles
-
-      has_particles = .false.
-
-      curl => finest%level
-      do while (associated(curl))
-         cgl => curl%first
-         do while (associated(cgl))
-            if (associated(cgl%cg%pset%first)) has_particles = .true.
-            cgl => cgl%nxt
-         enddo
-         curl => curl%coarser
-      enddo
-      if (has_particles) call die("[rebalance:reshuffle] Particles aren't supported yet")
-#endif /* NBODY */
+#if defined(GRAV) && defined(NBODY)
+      logical :: in, phy, out, fin, indomain
+      type(particle), pointer :: part
+#endif /* GRAV && NBODY */
 
       ! Count the number of fields on any of the base level cg.
       ! Assume that base level and above have the same set of fields. Levels coarser than base may have different set of fields.
@@ -476,7 +476,7 @@ contains
       endif
       call piernik_MPI_Allreduce(totfld, pMAX)
 
-      s = 0
+      s = 0  ! The number of cg to send
       if (master) then
          curl => finest%level
          do while (associated(curl))
@@ -487,7 +487,7 @@ contains
       call piernik_MPI_Bcast(s)
 
       call ppp_main%start(gp_label, PPP_AMR)
-      allocate(gptemp(I_OFF:I_D_P, s), cglepa(s))
+      allocate(gptemp(I_OFF:I_NP, s), cglepa(s))
       if (master) then
          p = 0
          curl => finest%level
@@ -495,7 +495,7 @@ contains
             do i = lbound(curl%gp%list, dim=1, kind=4), ubound(curl%gp%list, dim=1, kind=4)
                if (curl%gp%list(i)%cur_proc /= curl%gp%list(i)%dest_proc) then
                   p = p + I_ONE
-                  gptemp(:, p) = [ curl%gp%list(i)%off, int( [ curl%gp%list(i)%n_b, curl%gp%list(i)%cur_gid, curl%l%id, curl%gp%list(i)%cur_proc, curl%gp%list(i)%dest_proc ], kind=8) ]
+                  gptemp(:, p) = [ curl%gp%list(i)%off, int( [ curl%gp%list(i)%n_b, curl%gp%list(i)%cur_gid, curl%l%id, curl%gp%list(i)%cur_proc, curl%gp%list(i)%dest_proc, curl%gp%list(i)%n_part ], kind=8) ]
                endif
             enddo
             curl => curl%coarser
@@ -521,7 +521,7 @@ contains
                   found = .false.
                   cgl => curl%first
                   do while (associated(cgl))
-                     if (cgl%cg%grid_id == gptemp(I_GID,i)) then
+                     if (cgl%cg%grid_id == gptemp(I_GID, i)) then
                         found = .true.
                         cglepa(i)%p => cgl
                         allocate(cglepa(i)%tbuf(totfld, cgl%cg%n_(xdim), cgl%cg%n_(ydim), cgl%cg%n_(zdim)))
@@ -540,6 +540,28 @@ contains
                               s = s + 1
                            endif
                         enddo
+
+#if defined(GRAV) && defined(NBODY)
+                        ! Make copy of the particles here
+                        allocate(cglepa(i)%pbuf(npf, gptemp(I_NP, i)))
+
+                        part => cgl%cg%pset%first
+                        p = 1
+                        do while (associated(part))
+                           cglepa(i)%pbuf(P_ID, p)            = part%pdata%pid
+                           cglepa(i)%pbuf(P_MASS, p)          = part%pdata%mass
+                           cglepa(i)%pbuf(P_POS_X:P_POS_Z, p) = part%pdata%pos
+                           cglepa(i)%pbuf(P_VEL_X:P_VEL_Z, p) = part%pdata%vel
+                           cglepa(i)%pbuf(P_ACC_X:P_ACC_Z, p) = part%pdata%acc
+                           cglepa(i)%pbuf(P_ENER, p)          = part%pdata%energy
+                           cglepa(i)%pbuf(P_TFORM, p)         = part%pdata%tform
+                           cglepa(i)%pbuf(P_TDYN, p)          = part%pdata%tdyn
+
+                           p = p + I_ONE
+                           part => part%nxt
+                        enddo
+#endif /* GRAV && NBODY */
+
                         exit
                      endif
                      cgl => cgl%nxt
@@ -548,6 +570,14 @@ contains
                   nr = nr + I_ONE
                   if (nr > size(req, dim=1)) call inflate_req
                   call MPI_Isend(cglepa(i)%tbuf, size(cglepa(i)%tbuf, kind=4), MPI_DOUBLE_PRECISION, int(gptemp(I_D_P, i), kind=4), i, shuff_comm, req(nr), err_mpi)
+
+#if defined(GRAV) && defined(NBODY)
+                  ! Isend for particles
+                  nr = nr + I_ONE
+                  if (nr > size(req, dim=1)) call inflate_req
+                  call MPI_Isend(cglepa(i)%pbuf, size(cglepa(i)%pbuf, kind=4), MPI_DOUBLE_PRECISION, int(gptemp(I_D_P, i), kind=4), i, shuff_comm, req(nr), err_mpi)
+#endif /* GRAV && NBODY */
+
                endif
                if (gptemp(I_D_P, i) == proc) then ! receive
                   n_gid = 1
@@ -567,6 +597,13 @@ contains
                   nr = nr + I_ONE
                   if (nr > size(req, dim=1)) call inflate_req
                   call MPI_Irecv(cglepa(i)%tbuf, size(cglepa(i)%tbuf, kind=4), MPI_DOUBLE_PRECISION, int(gptemp(I_C_P, i), kind=4), i, shuff_comm, req(nr), err_mpi)
+
+#if defined(GRAV) && defined(NBODY)
+                  ! Irecv for particles
+                  allocate(cglepa(i)%pbuf(npf, gptemp(I_NP, i)))
+                  call MPI_Irecv(cglepa(i)%pbuf, size(cglepa(i)%pbuf, kind=4), MPI_DOUBLE_PRECISION, int(gptemp(I_C_P, i), kind=4), i, shuff_comm, req(nr), err_mpi)
+#endif /* GRAV && NBODY */
+
                endif
             endif
          enddo
@@ -590,6 +627,11 @@ contains
                   cg => cgl%cg
                   call all_lists%forget(cg)
                   curl%recently_changed = .true.
+
+#if defined(GRAV) && defined(NBODY)
+                  deallocate(cglepa(i)%pbuf)
+#endif /* GRAV && NBODY */
+
                endif
                if (gptemp(I_D_P, i) == proc) then ! copy received
                   s = lbound(cglepa(i)%tbuf, dim=1)
@@ -606,6 +648,21 @@ contains
                      endif
                   enddo
                   deallocate(cglepa(i)%tbuf)
+
+#if defined(GRAV) && defined(NBODY)
+                  ! assign imported particles
+                  do p = lbound(cglepa(i)%pbuf, 2, kind=4), ubound(cglepa(i)%pbuf, 2, kind=4)
+                     indomain = particle_in_area(cglepa(i)%pbuf(P_POS_X:P_POS_Z, p), dom%edge)
+                     call is_part_in_cg(cgl%cg, cglepa(i)%pbuf(P_POS_X:P_POS_Z, p), indomain, in, phy, out, fin)
+                     call cgl%cg%pset%add(nint(cglepa(i)%pbuf(P_ID, p), kind=4), cglepa(i)%pbuf(P_MASS, p), &
+                          cglepa(i)%pbuf(P_POS_X:P_POS_Z, p), cglepa(i)%pbuf(P_VEL_X:P_VEL_Z, p), &
+                          cglepa(i)%pbuf(P_ACC_X:P_ACC_Z, p), cglepa(i)%pbuf(P_ENER, p), &
+                          in, phy, out, fin, &
+                          cglepa(i)%pbuf(P_TFORM, p), cglepa(i)%pbuf(P_TDYN, p))
+                  enddo
+                  deallocate(cglepa(i)%pbuf)
+#endif /* GRAV && NBODY */
+
                endif
             endif
          enddo

--- a/src/grid/sort_piece_list.F90
+++ b/src/grid/sort_piece_list.F90
@@ -46,6 +46,7 @@ module sort_piece_list
       integer(kind=4)                   :: cur_gid   !< current grid_id
       integer(kind=4)                   :: cur_proc  !< current process number
       integer(kind=4)                   :: dest_proc !< process number according to ideal ordering
+      integer(kind=4)                   :: n_part    !< number of particles
       real                              :: weight    !< an estimate of cg cost
       real                              :: cweight   !< cumulative cost for id <= own id
    contains
@@ -112,6 +113,7 @@ contains
       this%cur_proc  = proc
       this%dest_proc = INVALID
       this%id        = INVALID
+      this%n_part    = 0
 
       ! Use the provided weight or use total cell count.
       if (present(weight)) then

--- a/src/particles/particle_types.F90
+++ b/src/particles/particle_types.F90
@@ -76,6 +76,7 @@ module particle_types
    contains
       procedure :: init                      !< initialize the list
       procedure :: print                     !< print the list
+      procedure :: count_phy                 !< count particles with phy flag set
       procedure :: cleanup                   !< delete the list
       procedure :: remove                    !< remove a particle
       !procedure :: merge_parts              !< merge two particles
@@ -83,6 +84,7 @@ module particle_types
       !procedure :: particle_with_id_exists  !< Check if particle no. "i" exists
       !generic, public :: exists => particle_with_id_exists
       generic, public :: add => add_part_list
+      generic, public :: count => count_phy
    end type particle_set
 
 contains
@@ -192,6 +194,27 @@ contains
       end subroutine prntline
 
    end subroutine print
+
+!> \brief count particles with phy flag set
+
+   integer(kind=4) function count_phy(this) result(n_part)
+
+      use constants, only: I_ONE
+
+      implicit none
+
+      class(particle_set), intent(in) :: this  !< an object invoking the type-bound procedure
+
+      type(particle), pointer :: pset
+
+      n_part = 0
+      pset => this%first
+      do while (associated(pset))
+         if (pset%pdata%phy) n_part = n_part + I_ONE
+         pset => pset%nxt
+      enddo
+
+   end function count_phy
 
 !> \brief delete the list
 

--- a/src/particles/particle_types.F90
+++ b/src/particles/particle_types.F90
@@ -34,9 +34,7 @@ module particle_types
 
    implicit none
 
-   private
-   public :: particle, particle_set, particle_data, npb
-   public :: P_ID, P_MASS, P_POS_X, P_POS_Y, P_POS_Z, P_VEL_X, P_VEL_Y, P_VEL_Z, P_ACC_X, P_ACC_Y, P_ACC_Z, P_ENER, P_TFORM, P_TDYN
+   public ! QA_WARN no secrets are kept here
 
    integer(kind=4), parameter :: npb = 2   !< number of cells between in and phy or between phy and out boundaries
 
@@ -44,6 +42,7 @@ module particle_types
    enum, bind(C)
       enumerator :: P_ID=1, P_MASS, P_POS_X, P_POS_Y, P_POS_Z, P_VEL_X, P_VEL_Y, P_VEL_Z, P_ACC_X, P_ACC_Y, P_ACC_Z, P_ENER, P_TFORM, P_TDYN
    end enum
+   integer(kind=4), parameter :: npf = P_TDYN  !< last enumerated element: the number of single particle fields
 
    !> \brief Particle type
 
@@ -299,8 +298,8 @@ contains
       class(particle_set),     intent(inout) :: this !< an object invoking the type-bound procedure
       type(particle), pointer, intent(inout) :: pset
 
-      if (.not. associated(pset)) call die("[particle removal] tried to remove null() element")
-      if (.not. associated(this%first)) call die("[particle removal] this%cnt <=0 .and. associated(this%first)")
+      if (.not. associated(pset)) call die("[particle_types:remove] tried to remove null() element")
+      if (.not. associated(this%first)) call die("[particle_types:remove] .not. associated(this%first)")
 
       if (associated(this%first, pset)) this%first => this%first%nxt
       if (associated(this%last,  pset)) this%last  => this%last%prv
@@ -309,6 +308,8 @@ contains
       deallocate(pset%pdata)
       deallocate(pset)
       this%cnt = this%cnt - I_ONE
+
+      if (this%cnt < 0) call die("[particle_types:remove] this%cnt < 0")
 
    end subroutine remove
 

--- a/src/particles/particle_types.F90
+++ b/src/particles/particle_types.F90
@@ -36,24 +36,26 @@ module particle_types
 
    private
    public :: particle, particle_set, particle_data, npb
+   public :: P_ID, P_MASS, P_POS_X, P_POS_Y, P_POS_Z, P_VEL_X, P_VEL_Y, P_VEL_Z, P_ACC_X, P_ACC_Y, P_ACC_Z, P_ENER, P_TFORM, P_TDYN
 
    integer(kind=4), parameter :: npb = 2   !< number of cells between in and phy or between phy and out boundaries
 
-   !>
-   !! \brief simple particle: just mass and position
-   !!
-   !! \todo Extend it a bit
-   !<
+   !> \brief enumerators for packung and unpacking the particles for teleportation to another cg
+   enum, bind(C)
+      enumerator :: P_ID=1, P_MASS, P_POS_X, P_POS_Y, P_POS_Z, P_VEL_X, P_VEL_Y, P_VEL_Z, P_ACC_X, P_ACC_Y, P_ACC_Z, P_ENER, P_TFORM, P_TDYN
+   end enum
+
+   !> \brief Particle type
 
    type :: particle_data
       integer(kind=4)        :: pid            !< particle ID
       real                   :: mass           !< mass of the particle
-      real                   :: tform          !< formation time of the particle
-      real                   :: tdyn           !< dynamical time for SF
       real, dimension(ndims) :: pos            !< physical position
       real, dimension(ndims) :: vel            !< particle velocity
       real, dimension(ndims) :: acc            !< acceleration of the particle
       real                   :: energy         !< total energy of particle
+      real                   :: tform          !< formation time of the particle
+      real                   :: tdyn           !< dynamical time for SF
       logical                :: in, phy, out   !< Flags to locate particle in the inner part of the domain or the outer part
       logical                :: fin            !< this flag is true if the particle is located in a finest level cell
       logical                :: outside        !< this flag is true if the particle is outside the domain

--- a/src/particles/particle_utils.F90
+++ b/src/particles/particle_utils.F90
@@ -35,13 +35,15 @@
 module particle_utils
 ! pulled by NBODY
 
+   use particle_types, only: P_TDYN
+
    implicit none
 
    private
    public :: add_part_in_proper_cg, is_part_in_cg, npf
    public :: count_cg_particles, count_all_particles, global_count_all_particles, part_leave_cg, detach_particle, global_balance_particles
 
-   integer(kind=4), parameter :: npf = 14  !< number of single particle fields
+   integer(kind=4), parameter :: npf = P_TDYN  !< number of single particle fields
 
 contains
 
@@ -418,7 +420,7 @@ contains
 
    function collect_single_part_fields(ind, p) result(pinfo)
 
-      use particle_types, only: particle_data
+      use particle_types, only: particle_data, P_ID, P_MASS, P_POS_X, P_POS_Z, P_VEL_X, P_VEL_Z, P_ACC_X, P_ACC_Z, P_ENER, P_TFORM, P_TDYN
 
       implicit none
 
@@ -426,15 +428,15 @@ contains
       integer,             intent(inout) :: ind
       type(particle_data), intent(in)    :: p
 
-      pinfo(1)    = p%pid
-      if (.not. (pinfo(1) >=1)) print *, 'error, id cannot be zero', ind, pinfo(1)
-      pinfo(2)    = p%mass
-      pinfo(3:5)  = p%pos
-      pinfo(6:8)  = p%vel
-      pinfo(9:11) = p%acc
-      pinfo(12)   = p%energy
-      pinfo(13)   = p%tform
-      pinfo(14)   = p%tdyn
+      pinfo(P_ID)            = p%pid
+      if (.not. (pinfo(P_ID) >=1)) print *, 'error, id cannot be zero', ind, pinfo(P_ID)
+      pinfo(P_MASS)          = p%mass
+      pinfo(P_POS_X:P_POS_Z) = p%pos
+      pinfo(P_VEL_X:P_VEL_Z) = p%vel
+      pinfo(P_ACC_X:P_ACC_Z) = p%acc
+      pinfo(P_ENER)          = p%energy
+      pinfo(P_TFORM)         = p%tform
+      pinfo(P_TDYN)          = p%tdyn
 
       ind = ind + npf
 
@@ -442,8 +444,8 @@ contains
 
    subroutine unpack_single_part_fields(ind, pinfo)
 
-      use constants, only: ndims
-
+      use constants,      only: ndims
+      use particle_types, only: P_ID, P_MASS, P_POS_X, P_POS_Z, P_VEL_X, P_VEL_Z, P_ACC_X, P_ACC_Z, P_ENER, P_TFORM, P_TDYN
       implicit none
 
       integer,              intent(inout) :: ind
@@ -454,14 +456,14 @@ contains
       real                                :: mass, ener, tform, tdyn
       logical                             :: attributed
 
-      pid   = nint(pinfo(1), kind=4)
-      mass  = pinfo(2)
-      pos   = pinfo(3:5)
-      vel   = pinfo(6:8)
-      acc   = pinfo(9:11)
-      ener  = pinfo(12)
-      tform = pinfo(13)
-      tdyn  = pinfo(14)
+      pid   = nint(pinfo(P_ID), kind=4)
+      mass  = pinfo(P_MASS)
+      pos   = pinfo(P_POS_X:P_POS_Z)
+      vel   = pinfo(P_VEL_X:P_VEL_Z)
+      acc   = pinfo(P_ACC_X:P_ACC_Z)
+      ener  = pinfo(P_ENER)
+      tform = pinfo(P_TFORM)
+      tdyn  = pinfo(P_TDYN)
       call add_part_in_proper_cg(pid, mass, pos, vel, acc, ener, tform, tdyn, attributed) ! TO DO IN AMR USE GRID_ID TO CUT THE SEARCH SHORT
       if (.not. attributed) print *, 'error, particle', pid, 'cannot be attributed! ', pos ! NON-AMR CHECK ONLY
       ind = ind + npf


### PR DESCRIPTION
No need to disable reshuffling by adjusting the `oop_thr`. Dynamic refinement and derefinement stiil needs attention (especially derefinement).